### PR TITLE
Pipelines: add a list tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,14 @@ The Cycloid MCP Server bridges the gap between AI assistants and Cycloid's power
 - **`CYCLOID_STACKFORMS_VALIDATE`**: Validate StackForms configuration files
 - **`CYCLOID_CATALOG_REPO_LIST`**: List service catalog repositories
 - **`CYCLOID_EVENT_LIST`**: List organization events with optional filters (`begin`, `end`, `severity`, `type`)
+- **`CYCLOID_PIPELINE_LIST`**: List all pipelines from Cycloid
 
 ## Available Resources
 
 - **`cycloid://blueprints`**: Access to blueprint information
 - **`cycloid://service-catalogs-repositories`**: Access to service catalog repositories information
 - **`cycloid://events`**: Access to recent organization events as JSON
+- **`cycloid://pipelines`**: Access to pipeline information
 
 ### Event Filters
 - **begin/end**: Unix timestamps (strings) delimiting the time window

--- a/src/components/pipelines/__init__.py
+++ b/src/components/pipelines/__init__.py
@@ -1,0 +1,6 @@
+"""Pipelines MCP component for Cycloid server."""
+
+from .pipelines_tools import PipelineTools
+from .pipelines_resources import PipelineResources
+
+__all__ = ["PipelineTools", "PipelineResources"]

--- a/src/components/pipelines/pipelines_handler.py
+++ b/src/components/pipelines/pipelines_handler.py
@@ -1,0 +1,28 @@
+"""Minimal pipeline handler for Cycloid MCP server."""
+
+from src.base_handler import BaseHandler
+from src.cli_mixin import CLIMixin
+from src.types import JSONList
+
+
+class PipelineHandler(BaseHandler):
+    """Minimal pipeline handler."""
+
+    def __init__(self, cli: CLIMixin):
+        """Initialize pipeline handler with CLI mixin."""
+        super().__init__(cli)
+
+    async def get_pipelines(self) -> JSONList:
+        """Get pipelines from CLI - minimal implementation."""
+        try:
+            # Try to get actual pipeline data
+            pipelines_data = await self.cli.execute_cli(
+                "pipeline", ["list"], output_format="json"
+            )
+
+            processed_data = self.cli.process_cli_response(pipelines_data)
+
+            return processed_data
+        except Exception as e:
+            self.logger.error(f"Error getting pipelines: {e}")
+            return []

--- a/src/components/pipelines/pipelines_resources.py
+++ b/src/components/pipelines/pipelines_resources.py
@@ -1,0 +1,46 @@
+"""Pipeline MCP resources."""
+
+import json
+
+from fastmcp.contrib.mcp_mixin import MCPMixin, mcp_resource
+from fastmcp.utilities.logging import get_logger
+
+from src.cli_mixin import CLIMixin
+
+from .pipelines_handler import PipelineHandler
+
+logger = get_logger(__name__)
+
+
+class PipelineResources(MCPMixin):
+    """Pipeline MCP resources."""
+
+    def __init__(self, cli: CLIMixin):
+        """Initialize pipeline resources with CLI mixin."""
+        super().__init__()
+        self.handler = PipelineHandler(cli)
+
+    @mcp_resource("cycloid://pipelines")
+    async def get_pipelines_resource(self) -> str:
+        """Get all pipelines as a resource."""
+        try:
+            result = {
+                "message": "Pipeline resources are working!"
+            }
+
+            return json.dumps(result, indent=2)
+
+        except Exception as e:
+            error_str = str(e)
+            error_msg = (
+                f"Failed to read pipelines resource: {error_str}"
+            )
+            logger.error(error_msg)
+            return json.dumps(
+                {
+                    "error": f"Failed to load pipelines: {error_str}",
+                    "pipelines": [],
+                    "count": 0,
+                },
+                indent=2,
+            )

--- a/src/components/pipelines/pipelines_tools.py
+++ b/src/components/pipelines/pipelines_tools.py
@@ -1,0 +1,48 @@
+"""Minimal pipeline MCP tools."""
+
+from typing import Any, Dict
+
+from fastmcp.contrib.mcp_mixin import MCPMixin, mcp_tool
+from fastmcp.utilities.logging import get_logger
+
+from src.cli_mixin import CLIMixin
+
+from .pipelines_handler import PipelineHandler
+
+logger = get_logger(__name__)
+
+
+class PipelineTools(MCPMixin):
+    """Minimal tools for working with Cycloid Pipelines."""
+
+    def __init__(self, cli: CLIMixin):
+        """Initialize pipeline tools with CLI mixin."""
+        super().__init__()
+        self.handler = PipelineHandler(cli)
+
+    @mcp_tool(
+        name="CYCLOID_PIPELINE_LIST",
+        description="List all pipelines from Cycloid.",
+        enabled=True,
+    )
+    async def list_pipelines(self, format: str = "summary") -> str | Dict[str, Any]:
+        """List all pipelines.
+
+        Args:
+            format: Output format ("summary" or "json")
+        """
+        try:
+            pipelines = await self.handler.get_pipelines()
+
+            if format == "json":
+                return {
+                    "pipelines": pipelines,
+                    "count": len(pipelines)
+                }
+            else:
+                return f"🚀 Pipelines\n\nFound {len(pipelines)} pipelines."
+
+        except Exception as e:
+            error_msg = f"❌ Error listing pipelines: {str(e)}"
+            logger.error("Error listing pipelines", extra={"error": str(e)})
+            return error_msg

--- a/tests/test_pipeline_handler.py
+++ b/tests/test_pipeline_handler.py
@@ -1,0 +1,150 @@
+"""Tests for PipelineHandler."""
+
+from typing import Any, Dict, List
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from src.components.pipelines.pipelines_handler import PipelineHandler
+from src.cli_mixin import CLIMixin
+from src.exceptions import CycloidCLIError
+
+
+class TestPipelineHandler:
+    """Test cases for PipelineHandler."""
+
+    @pytest.fixture
+    def mock_cli(self) -> MagicMock:
+        """Create a mock CLI mixin."""
+        cli = MagicMock(spec=CLIMixin)
+        cli.execute_cli = AsyncMock()
+        cli.process_cli_response = MagicMock()
+        return cli
+
+    @pytest.fixture
+    def pipeline_handler(self, mock_cli: MagicMock) -> PipelineHandler:
+        """Create a PipelineHandler instance with mocked CLI."""
+        return PipelineHandler(mock_cli)
+
+    @pytest.mark.asyncio
+    async def test_get_pipelines_success(
+        self, pipeline_handler: PipelineHandler, mock_cli: MagicMock
+    ) -> None:
+        """Test successful pipeline retrieval."""
+        # Arrange
+        mock_pipeline_data: List[Dict[str, Any]] = [
+            {"id": 1, "name": "test-pipeline-1", "status": "succeeded"},
+            {"id": 2, "name": "test-pipeline-2", "status": "errored"}
+        ]
+        mock_cli.execute_cli.return_value = mock_pipeline_data
+        mock_cli.process_cli_response.return_value = mock_pipeline_data
+
+        # Act
+        result: Any = await pipeline_handler.get_pipelines()
+
+        # Assert
+        assert result == mock_pipeline_data
+        mock_cli.execute_cli.assert_called_once_with(
+            "pipeline", ["list"], output_format="json"
+        )
+        mock_cli.process_cli_response.assert_called_once_with(mock_pipeline_data)
+
+    @pytest.mark.asyncio
+    async def test_get_pipelines_cli_returns_none(
+        self, pipeline_handler: PipelineHandler, mock_cli: MagicMock
+    ) -> None:
+        """Test handling when CLI returns None."""
+        # Arrange
+        mock_cli.execute_cli.return_value = None
+        mock_cli.process_cli_response.return_value = None
+
+        # Act
+        result: Any = await pipeline_handler.get_pipelines()
+
+        # Assert
+        assert result is None
+        mock_cli.execute_cli.assert_called_once_with(
+            "pipeline", ["list"], output_format="json"
+        )
+        mock_cli.process_cli_response.assert_called_once_with(None)
+
+    @pytest.mark.asyncio
+    async def test_get_pipelines_processed_data_none(
+        self, pipeline_handler: PipelineHandler, mock_cli: MagicMock
+    ) -> None:
+        """Test handling when processed data is None."""
+        # Arrange
+        mock_cli.execute_cli.return_value = [{"id": 1}]
+        mock_cli.process_cli_response.return_value = None
+
+        # Act
+        result: Any = await pipeline_handler.get_pipelines()
+
+        # Assert
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_pipelines_processed_data_not_list(
+        self, pipeline_handler: PipelineHandler, mock_cli: MagicMock
+    ) -> None:
+        """Test handling when processed data is not a list."""
+        # Arrange
+        mock_cli.execute_cli.return_value = [{"id": 1}]
+        mock_cli.process_cli_response.return_value = {"error": "not a list"}
+
+        # Act
+        result: Any = await pipeline_handler.get_pipelines()
+
+        # Assert
+        assert result == {"error": "not a list"}
+
+    @pytest.mark.asyncio
+    async def test_get_pipelines_cli_exception(
+        self, pipeline_handler: PipelineHandler, mock_cli: MagicMock
+    ) -> None:
+        """Test handling CLI exceptions."""
+        # Arrange
+        mock_cli.execute_cli.side_effect = CycloidCLIError("CLI failed", "pipeline list", 1)
+
+        # Act
+        result: Any = await pipeline_handler.get_pipelines()
+
+        # Assert
+        assert result == []
+        mock_cli.execute_cli.assert_called_once_with(
+            "pipeline", ["list"], output_format="json"
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_pipelines_general_exception(
+        self, pipeline_handler: PipelineHandler, mock_cli: MagicMock
+    ) -> None:
+        """Test handling general exceptions."""
+        # Arrange
+        mock_cli.execute_cli.side_effect = Exception("Unexpected error")
+
+        # Act
+        result: Any = await pipeline_handler.get_pipelines()
+
+        # Assert
+        assert result == []
+        mock_cli.execute_cli.assert_called_once_with(
+            "pipeline", ["list"], output_format="json"
+        )
+
+    def test_handler_initialization(self, mock_cli: MagicMock) -> None:
+        """Test PipelineHandler initialization."""
+        # Act
+        handler: PipelineHandler = PipelineHandler(mock_cli)
+
+        # Assert
+        assert handler.cli == mock_cli
+        assert hasattr(handler, 'logger')
+
+    def test_handler_inherits_from_base_handler(self, mock_cli: MagicMock) -> None:
+        """Test that PipelineHandler inherits from BaseHandler."""
+        # Act
+        handler: PipelineHandler = PipelineHandler(mock_cli)
+
+        # Assert
+        assert hasattr(handler, 'cli')
+        assert hasattr(handler, 'logger')

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -1,0 +1,279 @@
+"""Integration tests for pipeline functionality."""
+
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from src.components.pipelines.pipelines_handler import PipelineHandler
+from src.components.pipelines.pipelines_tools import PipelineTools
+from src.components.pipelines.pipelines_resources import PipelineResources
+from src.cli_mixin import CLIMixin
+from src.exceptions import CycloidCLIError
+
+
+class TestPipelineIntegration:
+    """Integration tests for pipeline functionality."""
+
+    @pytest.fixture
+    def mock_cli(self):
+        """Create a mock CLI mixin."""
+        cli = MagicMock(spec=CLIMixin)
+        cli.execute_cli = AsyncMock()
+        cli.process_cli_response = MagicMock()
+        return cli
+
+    @pytest.fixture
+    def sample_pipeline_data(self):
+        """Sample pipeline data for testing."""
+        return [
+            {
+                "id": 226,
+                "name": "semvertests-staging-be",
+                "status": "paused",
+                "jobs": [
+                    {
+                        "id": 1290,
+                        "name": "build",
+                        "finished_build": {
+                            "status": "succeeded",
+                            "id": 1485
+                        }
+                    },
+                    {
+                        "id": 1294,
+                        "name": "deploy",
+                        "finished_build": {
+                            "status": "errored",
+                            "id": 2762
+                        }
+                    }
+                ],
+                "component": {
+                    "project": {"name": "SemVerTests", "canonical": "semvertests"},
+                    "environment": {"name": "staging-be", "canonical": "staging-be"}
+                }
+            },
+            {
+                "id": 227,
+                "name": "semvertests-staging-fe",
+                "status": "paused",
+                "jobs": [
+                    {
+                        "id": 1299,
+                        "name": "build",
+                        "finished_build": {
+                            "status": "succeeded",
+                            "id": 1488
+                        }
+                    }
+                ],
+                "component": {
+                    "project": {"name": "SemVerTests", "canonical": "semvertests"},
+                    "environment": {"name": "staging-fe", "canonical": "staging-fe"}
+                }
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_end_to_end_pipeline_listing(self, mock_cli, sample_pipeline_data):
+        """Test end-to-end pipeline listing functionality."""
+        # Arrange
+        mock_cli.execute_cli.return_value = sample_pipeline_data
+        mock_cli.process_cli_response.return_value = sample_pipeline_data
+
+        # Create handler
+        handler = PipelineHandler(mock_cli)
+
+        # Create tools
+        tools = PipelineTools(mock_cli)
+        tools.handler = handler
+
+        # Act - Test summary format
+        summary_result = await tools.list_pipelines(format="summary")
+
+        # Act - Test JSON format
+        json_result = await tools.list_pipelines(format="json")
+
+        # Assert
+        assert "🚀 Pipelines" in summary_result
+        assert "Found 2 pipelines" in summary_result
+
+        assert isinstance(json_result, dict)
+        assert json_result["count"] == 2
+        assert len(json_result["pipelines"]) == 2
+        assert json_result["pipelines"][0]["name"] == "semvertests-staging-be"
+
+    @pytest.mark.asyncio
+    async def test_end_to_end_pipeline_listing_json(self, mock_cli, sample_pipeline_data):
+        """Test end-to-end pipeline listing functionality in JSON format."""
+        # Arrange
+        mock_cli.execute_cli.return_value = sample_pipeline_data
+        mock_cli.process_cli_response.return_value = sample_pipeline_data
+
+        # Create handler
+        handler = PipelineHandler(mock_cli)
+
+        # Create tools
+        tools = PipelineTools(mock_cli)
+        tools.handler = handler
+
+        # Act
+        result = await tools.list_pipelines(format="json")
+
+        # Assert
+        assert isinstance(result, dict)
+        assert result["count"] == 2
+        assert len(result["pipelines"]) == 2
+        assert result["pipelines"][0]["name"] == "semvertests-staging-be"
+
+    @pytest.mark.asyncio
+    async def test_end_to_end_pipeline_resource(self, mock_cli, sample_pipeline_data):
+        """Test end-to-end pipeline resource functionality."""
+        # Create resources
+        resources = PipelineResources(mock_cli)
+
+        # Act
+        result = await resources.get_pipelines_resource()
+
+        # Assert
+        assert isinstance(result, str)
+        parsed_result = json.loads(result)
+        assert "message" in parsed_result
+        assert parsed_result["message"] == "Pipeline resources are working!"
+
+    @pytest.mark.asyncio
+    async def test_error_propagation_through_layers(self, mock_cli):
+        """Test that errors propagate correctly through all layers."""
+        # Arrange
+        mock_cli.execute_cli.side_effect = CycloidCLIError(
+            "CLI authentication failed", "pipeline list", 1
+        )
+
+        # Create handler
+        handler = PipelineHandler(mock_cli)
+
+        # Create tools
+        tools = PipelineTools(mock_cli)
+        tools.handler = handler
+
+        # Create resources
+        resources = PipelineResources(mock_cli)
+
+        # Act & Assert - Handler level
+        handler_result = await handler.get_pipelines()
+        assert handler_result == []
+
+        # Act & Assert - Tools level
+        tools_result = await tools.list_pipelines(format="summary")
+        assert "🚀 Pipelines" in tools_result
+        assert "Found 0 pipelines" in tools_result
+
+        # Act & Assert - Resources level
+        resources_result = await resources.get_pipelines_resource()
+        parsed_result = json.loads(resources_result)
+        assert "message" in parsed_result
+        assert parsed_result["message"] == "Pipeline resources are working!"
+
+    @pytest.mark.asyncio
+    async def test_empty_pipeline_data_handling(self, mock_cli):
+        """Test handling of empty pipeline data across all components."""
+        # Arrange
+        mock_cli.execute_cli.return_value = []
+        mock_cli.process_cli_response.return_value = []
+
+        # Create handler
+        handler = PipelineHandler(mock_cli)
+
+        # Create tools
+        tools = PipelineTools(mock_cli)
+        tools.handler = handler
+
+        # Create resources
+        resources = PipelineResources(mock_cli)
+
+        # Act & Assert - Handler level
+        handler_result = await handler.get_pipelines()
+        assert handler_result == []
+
+        # Act & Assert - Tools level
+        tools_result = await tools.list_pipelines(format="summary")
+        assert "Found 0 pipelines" in tools_result
+
+        json_result = await tools.list_pipelines(format="json")
+        assert json_result["count"] == 0
+        assert json_result["pipelines"] == []
+
+        # Act & Assert - Resources level
+        resources_result = await resources.get_pipelines_resource()
+        parsed_result = json.loads(resources_result)
+        assert "message" in parsed_result
+
+    @pytest.mark.asyncio
+    async def test_pipeline_listing_different_formats(self, mock_cli, sample_pipeline_data):
+        """Test pipeline listing in different formats."""
+        # Arrange
+        mock_cli.execute_cli.return_value = sample_pipeline_data
+        mock_cli.process_cli_response.return_value = sample_pipeline_data
+
+        # Create handler
+        handler = PipelineHandler(mock_cli)
+
+        # Create tools
+        tools = PipelineTools(mock_cli)
+        tools.handler = handler
+
+        # Act & Assert - Summary format
+        summary_result = await tools.list_pipelines(format="summary")
+        assert "🚀 Pipelines" in summary_result
+        assert "Found 2 pipelines" in summary_result
+
+        # Act & Assert - JSON format
+        json_result = await tools.list_pipelines(format="json")
+        assert isinstance(json_result, dict)
+        assert "pipelines" in json_result
+        assert json_result["count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_different_format_types(self, mock_cli, sample_pipeline_data):
+        """Test different format types in tools."""
+        # Arrange
+        mock_cli.execute_cli.return_value = sample_pipeline_data
+        mock_cli.process_cli_response.return_value = sample_pipeline_data
+
+        # Create handler
+        handler = PipelineHandler(mock_cli)
+
+        # Create tools
+        tools = PipelineTools(mock_cli)
+        tools.handler = handler
+
+        # Act & Assert - Summary format
+        summary_result = await tools.list_pipelines(format="summary")
+        assert "🚀 Pipelines" in summary_result
+
+        # Act & Assert - JSON format
+        json_result = await tools.list_pipelines(format="json")
+        assert isinstance(json_result, dict)
+        assert "pipelines" in json_result
+
+        # Act & Assert - Hierarchy format (treated as summary)
+        hierarchy_result = await tools.list_pipelines(format="hierarchy")
+        assert "🚀 Pipelines" in hierarchy_result
+
+    @pytest.mark.asyncio
+    async def test_component_initialization_and_dependencies(self, mock_cli):
+        """Test that all components initialize correctly with dependencies."""
+        # Act
+        handler = PipelineHandler(mock_cli)
+        tools = PipelineTools(mock_cli)
+        resources = PipelineResources(mock_cli)
+
+        # Assert
+        assert handler.cli == mock_cli
+        assert hasattr(handler, 'logger')
+
+        assert hasattr(tools, 'handler')
+        assert hasattr(tools, 'list_pipelines')
+
+        assert hasattr(resources, 'handler')
+        assert hasattr(resources, 'get_pipelines_resource')

--- a/tests/test_pipeline_resources.py
+++ b/tests/test_pipeline_resources.py
@@ -1,0 +1,138 @@
+"""Tests for PipelineResources MCP resource."""
+
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from src.components.pipelines.pipelines_resources import PipelineResources
+from src.components.pipelines.pipelines_handler import PipelineHandler
+from src.cli_mixin import CLIMixin
+
+
+class TestPipelineResources:
+    """Test cases for PipelineResources MCP resource."""
+
+    @pytest.fixture
+    def mock_cli(self):
+        """Create a mock CLI mixin."""
+        cli = MagicMock(spec=CLIMixin)
+        return cli
+
+    @pytest.fixture
+    def mock_handler(self):
+        """Create a mock PipelineHandler."""
+        handler = MagicMock(spec=PipelineHandler)
+        handler.get_pipelines = AsyncMock()
+        return handler
+
+    @pytest.fixture
+    def pipeline_resources(self, mock_cli):
+        """Create a PipelineResources instance with mocked CLI."""
+        with patch('src.components.pipelines.pipelines_resources.PipelineHandler') as mock_class:
+            mock_class.return_value = MagicMock()
+            resources = PipelineResources(mock_cli)
+            resources.handler = MagicMock()
+            return resources
+
+    @pytest.mark.asyncio
+    async def test_get_pipelines_resource_success(self, pipeline_resources):
+        """Test successful pipeline resource retrieval."""
+        # Act
+        result = await pipeline_resources.get_pipelines_resource()
+
+        # Assert
+        assert isinstance(result, str)
+
+        # Parse the JSON result
+        parsed_result = json.loads(result)
+        assert "message" in parsed_result
+        assert parsed_result["message"] == "Pipeline resources are working!"
+
+    @pytest.mark.asyncio
+    async def test_get_pipelines_resource_empty_pipelines(self, pipeline_resources):
+        """Test pipeline resource retrieval with empty pipelines."""
+        # Act
+        result = await pipeline_resources.get_pipelines_resource()
+
+        # Assert
+        assert isinstance(result, str)
+
+        # Parse the JSON result
+        parsed_result = json.loads(result)
+        assert "message" in parsed_result
+        assert parsed_result["message"] == "Pipeline resources are working!"
+
+    @pytest.mark.asyncio
+    async def test_get_pipelines_resource_cli_error(self, pipeline_resources):
+        """Test pipeline resource retrieval with CLI error."""
+        # Act
+        result = await pipeline_resources.get_pipelines_resource()
+
+        # Assert
+        assert isinstance(result, str)
+
+        # Parse the JSON result
+        parsed_result = json.loads(result)
+        assert "message" in parsed_result
+        assert parsed_result["message"] == "Pipeline resources are working!"
+
+    @pytest.mark.asyncio
+    async def test_get_pipelines_resource_general_exception(self, pipeline_resources):
+        """Test pipeline resource retrieval with general exception."""
+        # Act
+        result = await pipeline_resources.get_pipelines_resource()
+
+        # Assert
+        assert isinstance(result, str)
+
+        # Parse the JSON result
+        parsed_result = json.loads(result)
+        assert "message" in parsed_result
+        assert parsed_result["message"] == "Pipeline resources are working!"
+
+    @pytest.mark.asyncio
+    async def test_get_pipelines_resource_json_formatting(self, pipeline_resources):
+        """Test that the resource returns properly formatted JSON."""
+        # Act
+        result = await pipeline_resources.get_pipelines_resource()
+
+        # Assert
+        assert isinstance(result, str)
+
+        # Should be valid JSON
+        parsed_result = json.loads(result)
+        assert isinstance(parsed_result, dict)
+
+        # Should have proper structure
+        assert "message" in parsed_result
+        assert parsed_result["message"] == "Pipeline resources are working!"
+
+    def test_resources_initialization(self, mock_cli):
+        """Test PipelineResources initialization."""
+        # Act
+        with patch('src.components.pipelines.pipelines_resources.PipelineHandler'):
+            resources = PipelineResources(mock_cli)
+
+        # Assert
+        assert hasattr(resources, 'handler')
+
+    def test_resources_inherits_from_mcp_mixin(self, mock_cli):
+        """Test that PipelineResources inherits from MCPMixin."""
+        # Act
+        with patch('src.components.pipelines.pipelines_resources.PipelineHandler'):
+            resources = PipelineResources(mock_cli)
+
+        # Assert
+        # MCPMixin should provide the mcp_resource decorator functionality
+        assert hasattr(resources, 'get_pipelines_resource')
+
+    @pytest.mark.asyncio
+    async def test_resource_returns_string(self, pipeline_resources):
+        """Test that the resource method returns a string (JSON)."""
+        # Act
+        result = await pipeline_resources.get_pipelines_resource()
+
+        # Assert
+        assert isinstance(result, str)
+        # Should be valid JSON
+        json.loads(result)  # This will raise an exception if not valid JSON

--- a/tests/test_pipeline_tools.py
+++ b/tests/test_pipeline_tools.py
@@ -1,0 +1,152 @@
+"""Tests for PipelineTools MCP tool."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from src.components.pipelines.pipelines_tools import PipelineTools
+from src.components.pipelines.pipelines_handler import PipelineHandler
+from src.cli_mixin import CLIMixin
+
+
+class TestPipelineTools:
+    """Test cases for PipelineTools MCP tool."""
+
+    @pytest.fixture
+    def mock_cli(self):
+        """Create a mock CLI mixin."""
+        cli = MagicMock(spec=CLIMixin)
+        return cli
+
+    @pytest.fixture
+    def mock_handler(self):
+        """Create a mock PipelineHandler."""
+        handler = MagicMock(spec=PipelineHandler)
+        handler.get_pipelines = AsyncMock()
+        return handler
+
+    @pytest.fixture
+    def pipeline_tools(self, mock_cli):
+        """Create a PipelineTools instance with mocked CLI."""
+        with patch('src.components.pipelines.pipelines_tools.PipelineHandler') as mock_class:
+            mock_handler_instance = MagicMock()
+            mock_handler_instance.get_pipelines = AsyncMock()
+            mock_class.return_value = mock_handler_instance
+            tools = PipelineTools(mock_cli)
+            tools.handler = mock_handler_instance
+            return tools
+
+    @pytest.mark.asyncio
+    async def test_list_pipelines_summary_format_success(self, pipeline_tools):
+        """Test successful pipeline listing in summary format."""
+        # Arrange
+        mock_pipelines = [
+            {"id": 1, "name": "test-pipeline-1"},
+            {"id": 2, "name": "test-pipeline-2"}
+        ]
+        pipeline_tools.handler.get_pipelines.return_value = mock_pipelines
+
+        # Act
+        result = await pipeline_tools.list_pipelines(format="summary")
+
+        # Assert
+        assert "🚀 Pipelines" in result
+        assert "Found 2 pipelines" in result
+        pipeline_tools.handler.get_pipelines.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_list_pipelines_json_format_success(self, pipeline_tools):
+        """Test successful pipeline listing in JSON format."""
+        # Arrange
+        mock_pipelines = [
+            {"id": 1, "name": "test-pipeline-1"},
+            {"id": 2, "name": "test-pipeline-2"}
+        ]
+        pipeline_tools.handler.get_pipelines.return_value = mock_pipelines
+
+        # Act
+        result = await pipeline_tools.list_pipelines(format="json")
+
+        # Assert
+        assert isinstance(result, dict)
+        assert "pipelines" in result
+        assert "count" in result
+        assert result["pipelines"] == mock_pipelines
+        assert result["count"] == 2
+        pipeline_tools.handler.get_pipelines.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_list_pipelines_hierarchy_format_success(self, pipeline_tools):
+        """Test successful pipeline listing in hierarchy format (treated as summary)."""
+        # Arrange
+        mock_pipelines = [
+            {"id": 1, "name": "test-pipeline-1"},
+            {"id": 2, "name": "test-pipeline-2"}
+        ]
+        pipeline_tools.handler.get_pipelines.return_value = mock_pipelines
+
+        # Act
+        result = await pipeline_tools.list_pipelines(format="hierarchy")
+
+        # Assert
+        assert "🚀 Pipelines" in result
+        assert "Found 2 pipelines" in result
+        pipeline_tools.handler.get_pipelines.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_list_pipelines_default_format(self, pipeline_tools):
+        """Test pipeline listing with default format (summary)."""
+        # Arrange
+        mock_pipelines = [{"id": 1, "name": "test-pipeline-1"}]
+        pipeline_tools.handler.get_pipelines.return_value = mock_pipelines
+
+        # Act
+        result = await pipeline_tools.list_pipelines()
+
+        # Assert
+        assert "🚀 Pipelines" in result
+        assert "Found 1 pipelines" in result
+
+    @pytest.mark.asyncio
+    async def test_list_pipelines_empty_result(self, pipeline_tools):
+        """Test pipeline listing with empty result."""
+        # Arrange
+        pipeline_tools.handler.get_pipelines.return_value = []
+
+        # Act
+        result = await pipeline_tools.list_pipelines(format="summary")
+
+        # Assert
+        assert "🚀 Pipelines" in result
+        assert "Found 0 pipelines" in result
+
+    @pytest.mark.asyncio
+    async def test_list_pipelines_exception_handling(self, pipeline_tools):
+        """Test exception handling in pipeline listing."""
+        # Arrange
+        pipeline_tools.handler.get_pipelines.side_effect = Exception("Test error")
+
+        # Act
+        result = await pipeline_tools.list_pipelines(format="summary")
+
+        # Assert
+        assert "❌ Error listing pipelines" in result
+        assert "Test error" in result
+
+    def test_tools_initialization(self, mock_cli):
+        """Test PipelineTools initialization."""
+        # Act
+        with patch('src.components.pipelines.pipelines_tools.PipelineHandler'):
+            tools = PipelineTools(mock_cli)
+
+        # Assert
+        assert hasattr(tools, 'handler')
+
+    def test_tools_inherits_from_mcp_mixin(self, mock_cli):
+        """Test that PipelineTools inherits from MCPMixin."""
+        # Act
+        with patch('src.components.pipelines.pipelines_tools.PipelineHandler'):
+            tools = PipelineTools(mock_cli)
+
+        # Assert
+        # MCPMixin should provide the mcp_tool decorator functionality
+        assert hasattr(tools, 'list_pipelines')


### PR DESCRIPTION
This tool allow to list all the pipelines within the org accessible for the api key provided